### PR TITLE
Add SHA256 checksum utilities

### DIFF
--- a/Undecimus/source/utils.h
+++ b/Undecimus/source/utils.h
@@ -92,7 +92,8 @@ extern substitutor_info_t *substitutor_infos[];
 
 enum hashtype {
     HASHTYPE_MD5 = 0,
-    HASHTYPE_SHA1
+    HASHTYPE_SHA1,
+    HASHTYPE_SHA256
 };
 int proc_pidpath(pid_t pid, void *buffer, uint32_t buffersize);
 
@@ -140,6 +141,8 @@ static inline bool init_file(const char *file, int owner, mode_t mode) {
 
 int sha1_to_str(const unsigned char *hash, size_t hashlen, char *buf, size_t buflen);
 NSString *sha1sum(NSString *file);
+NSString *sha256sum(NSString *file);
+bool verifySha256Sums(NSString *sumFile);
 bool verifySha1Sums(NSString *sumFile);
 bool verifySums(NSString *sumFile, enum hashtype hash);
 int _system(const char *cmd);

--- a/Undecimus/source/utils.m
+++ b/Undecimus/source/utils.m
@@ -263,6 +263,36 @@ NSString *md5sum(NSString *file)
     return [NSString stringWithUTF8String:checksum];
 }
 
+NSString *sha256sum(NSString *file)
+{
+    uint8_t buffer[0x1000];
+    unsigned char md[CC_SHA256_DIGEST_LENGTH];
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:file])
+        return nil;
+
+    NSInputStream *fileStream = [NSInputStream inputStreamWithFileAtPath:file];
+    [fileStream open];
+
+    CC_SHA256_CTX c;
+    CC_SHA256_Init(&c);
+    while ([fileStream hasBytesAvailable]) {
+        NSInteger read = [fileStream read:buffer maxLength:0x1000];
+        CC_SHA256_Update(&c, buffer, (CC_LONG)read);
+    }
+
+    CC_SHA256_Final(md, &c);
+
+    char checksum[CC_SHA256_DIGEST_LENGTH * 2 + 1];
+    if (sha1_to_str(md, CC_SHA256_DIGEST_LENGTH, checksum, sizeof(checksum)) != ERR_SUCCESS)
+        return nil;
+    return [NSString stringWithUTF8String:checksum];
+}
+
+bool verifySha256Sums(NSString *sumFile) {
+    return verifySums(sumFile, HASHTYPE_SHA256);
+}
+
 bool verifySha1Sums(NSString *sumFile) {
     return verifySums(sumFile, HASHTYPE_SHA1);
 }
@@ -293,6 +323,9 @@ bool verifySums(NSString *sumFile, enum hashtype hash) {
                 break;
             case HASHTYPE_MD5:
                 fileSum = md5sum(suminfo[1]);
+                break;
+            case HASHTYPE_SHA256:
+                fileSum = sha256sum(suminfo[1]);
                 break;
         }
         if (![fileSum.lowercaseString isEqualToString:suminfo[0]]) {


### PR DESCRIPTION
## Summary
- extend `enum hashtype` with SHA256 support
- add `sha256sum` and verification helpers

## Testing
- `make clean`
- `make` *(fails: `xcodebuild: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850bd99952c8329933d4d13d70b543d